### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ if sys_version_info[:2] < (3, 4) or sys_platform == 'win32':
    print('''
 \nPSphinxTheme is only tested with Python 3.4.1 or higher:\n  current python version: {0:d}.{1:d}\n\n
 
-TESTED_HOST_OS: {3:}
+TESTED_HOST_OS: {2:}
 '''.format(sys_version_info[:2][0], sys_version_info[:2][1], TESTED_HOST_OS))
 
 # check some untested options


### PR DESCRIPTION
Otherwise the tuple tries to return an out of bounds value.

Note that [LCONF Lexer](https://github.com/LCONF/python_lconf_lexer) suffers from the same issue (the code is identical), so that will also need to be fixed ([patch submitted](https://github.com/LCONF/python_lconf_lexer/pull/1)) before this theme will install on Windows.

P.S. as a side, is there a reason you've turned off issues on this repo?